### PR TITLE
add: build_and_release.yml

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -1,0 +1,85 @@
+name: 📦 Build and Release
+
+on:
+  push:
+    paths:
+      - lib/justifi/version.rb
+
+jobs:
+  run_tests:
+    name: 📋 Verify
+    uses: justifi-tech/justifi-ruby/.github/workflows/verify.yml@main
+    if: github.ref == 'refs/heads/main'
+  build_and_release:
+    strategy:
+      matrix:
+        include:
+          - api_key: JUSTIFI_MACHINA_RUBYGEMS_API_KEY
+            bearer: false
+            gem_host: https://rubygems.org
+            pkg_host_name: rubygems.org
+          - api_key: JUSTIFI_MACHINA_GITHUB_TOKEN
+            bearer: true
+            gem_host: https://rubygems.pkg.github.com/${{ github.repository_owner }}
+            pkg_host_name: pkg.github.com
+
+    name: 📦 Package and Release on ${{ matrix.pkg_host_name }}
+    needs: run_tests
+    if: github.ref == 'refs/heads/main'
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Build API_KEY value
+        id: api_key
+        run: |
+          echo "::set-output name=value::${{ matrix.bearer && 'Bearer ' || '' }}${{ secrets[matrix.api_key] }}"
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Ruby and install gems
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: 2.6
+          rubygems: 3.2.32 # Required for GEM_HOST_API_KEY to work (delete if we use Ruby 3)
+
+      # The `computed` value here is to solve for `-pre` style tags.
+      # `raw_value` is what comes directly from the VERSION value, and
+      # `computed` is what `Gem::Version` will output
+      - name: Fetch Gem Version
+        id: gem_version
+        run: |
+          ruby -r ./lib/justifi/version.rb -e '
+            puts "::set-output name=raw_value::#{Justifi::VERSION}"
+            puts "::set-output name=computed::#{Gem::Version.new(Justifi::VERSION)}"
+          '
+
+      # Combination of bundler's release steps and the steps here:
+      #
+      #   https://github.com/rickstaa/action-create-tag/blob/main/entrypoint.sh
+      #
+      - name: Tag Release
+        id: git_tag
+        if: matrix.gem_host == 'https://rubygems.org' # only do this step 1 time
+        env:
+          TAG: v${{ steps.gem_version.outputs.raw_value }}
+          VERSION: ${{ steps.gem_version.outputs.raw_value }}
+        run: |
+          git config user.name "JustiFi Machina"
+          git config user.email "justifi.machina@justifi.ai"
+          git tag -a "${TAG}" -m "Version ${VERSION}" "${GITHUB_SHA}"
+          git remote set-url origin "https://justifi-machina:${{ secrets.JUSTIFI_MACHINA_GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git"
+          git push origin refs/tags/${TAG}
+
+      - name: Build gem
+        run: gem build justifi.gemspec
+
+      - name: Publish gem to GitHub packages
+        env:
+          GEM_HOST_API_KEY: ${{ steps.api_key.outputs.value }}
+          RUBYGEMS_HOST: ${{ matrix.gem_host }}
+          VERSION: ${{ steps.gem_version.outputs.computed }}
+        run: |
+          gem push --host ${RUBYGEMS_HOST} justifi-${VERSION}.gem

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches:
     - main
+  workflow_call:
 
 jobs:
   linters:

--- a/README.md
+++ b/README.md
@@ -191,3 +191,26 @@ refunds = refunds.previous_page
 payment = Justifi::Payment.get(payment_id: 'py_xyz')
 refund = Justifi::Refund.get(refund_id: 're_xyz')
 ```
+
+
+## Contributing
+
+### Release a new version of the gem
+
+Follow the steps below to make a release:
+
+1. Increment the version number in `lib/justifi/version.rb`
+2. Run `bundle`
+3. Commit the following file changes to your branch
+  - `Gemfile.lock`
+  - `lib/justifi/version.rb`
+4. Create and Merge your PR to `main`
+
+After this, the `.github/workflows/build_and_release.yml` will tag and release
+the gem to github packages.
+
+
+## Code of Conduct
+
+Everyone interacting in the JustApi project's codebases, issue trackers, chat
+rooms and mailing lists is expected to follow the [code of conduct][].

--- a/justifi.gemspec
+++ b/justifi.gemspec
@@ -13,8 +13,6 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://justifi.ai"
   spec.required_ruby_version = ">= 2.4"
 
-  spec.metadata["allowed_push_host"] = "https://rubygems.pkg.github.com"
-
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/justifi-tech/justifi-ruby"
   spec.metadata["github_repo"] = "ssh://github.com/justifi-tech/justifi-ruby"


### PR DESCRIPTION
Add Build and Release process to github actions.


TODO
----

- [x] Create `JUSTIFI_MACHINA_GITHUB_TOKEN` as an ORG secret
- [x] Create `JUSTIFI_MACHINA_RUBYGEMS_AUTH_TOKEN` as an ORG secret


Type of Change
--------------

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update
* [ ] This change is in scope for PCI
* [ ] This requires approval from UX
* [ ] This requires approval from Marketing


Links
-----

* resources used when building this action:
  - https://github.com/rickstaa/action-create-tag/blob/19e7d4fc/entrypoint.sh
  - https://github.com/voxpupuli/puppet-lint_modulesync_configs/blob/f7ddfda7//moduleroot/.github/workflows/release.yml.erb
  - https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
  - https://stackoverflow.com/questions/59191913/how-do-i-get-the-output-of-a-specific-step-in-github-actions


Steps for Testing/QA
--------------------

This will be done _**AFTER**_ the `TODO` section is completed, this is the process I will be taking to test this (it will be manual, and done once):

- Create a new branch with these changes: `gem-push-and-build-via-ci--QA`
- Update the `github.ref_name == "main"` in the workflow to point to the new branch
- Commit and push
- Update the gem version to `"1.0.10-testing-CI"`
- Commit and push
- Confirm that there:
  * Is a new gem available in rubygems.org
  * There is a tag `v0.3.1-testing-CI`
- Yank the gem and delete