### PR TITLE
Allow metadata params to be passed when creating a refund

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    justifi (0.6.0)
+    justifi (0.6.1)
 
 GEM
   remote: https://rubygems.org/
@@ -89,4 +89,4 @@ DEPENDENCIES
   webmock (>= 3.8.0)
 
 BUNDLED WITH
-   2.2.3
+   2.2.15

--- a/lib/justifi/payment.rb
+++ b/lib/justifi/payment.rb
@@ -11,8 +11,8 @@ module Justifi
           headers: headers)
       end
 
-      def create_refund(amount:, payment_id:, reason: nil, description: nil)
-        refund_params = {amount: amount, description: description, reason: reason}
+      def create_refund(amount:, payment_id:, reason: nil, description: nil, metadata: nil)
+        refund_params = {amount: amount, description: description, reason: reason, metadata: metadata}
         JustifiOperations.idempotently_request("/v1/payments/#{payment_id}/refunds",
           method: :post,
           params: refund_params,

--- a/lib/justifi/version.rb
+++ b/lib/justifi/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Justifi
-  VERSION = "0.6.0"
+  VERSION = "0.6.1"
 end

--- a/spec/justifi/payment_spec.rb
+++ b/spec/justifi/payment_spec.rb
@@ -109,7 +109,8 @@ RSpec.describe Justifi::Payment do
           amount: 1000,
           description: nil,
           reason: Justifi::REFUND_REASONS[2],
-          payment_id: created_payment.id
+          payment_id: created_payment.id,
+          metadata: {meta_id: "123_zxy"}
         }
       }
 

--- a/spec/justifi/refund_spec.rb
+++ b/spec/justifi/refund_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe Justifi::Refund do
       amount: 1000,
       description: nil,
       reason: Justifi::REFUND_REASONS[2],
-      payment_id: "py_xyz"
+      payment_id: "py_xyz",
+      metadata: nil
     }
   }
 


### PR DESCRIPTION
feat: allow metadata on create payments

<!--
Describe the rationale and use case for this pull request.  Provide any
background, examples, and images that provide further information to accurately
describe what it is that you are adding to the repo.  Add subsections as
necessary to organize and feel free to link and reference other PRs as
necessary, but also include them in the links section below as a quick
reference.

**Guidelines:**

* Keep Pull Request titles short and to the point, ideally under 72 characters
* Provide as much context/info in the description as necessary to get the
  reviewer up to the same domain knowledge level as yourself
* Keep code changes as short as possible and implementing a single
  feature/fix/refactoring, when possible
-->

Type of Change
--------------

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update
* [ ] This change is in scope for PCI
* [ ] This requires approval from UX
* [ ] This requires approval from Marketing


Links
-----

<!--
**Examples** 

* http://documentation.for/library/that/I/am/adding
* [relevant issue or pull_request](#123)
-->


Steps for Testing/QA
--------------------

<!--
If there are any manual steps that you would like the reviewer(s) to take to
verify your changes, please describe in detail the steps to reproduce the
features added by the pull request, or the bug before and after the change.
-->

Dev QA
--------

* [ ] Create a Payment using the gem
* [ ] Create a refund for this payment with metadata in it
* [ ] Check if the refund was created with the metatada