### PR TITLE
fix: README.md link for CODE_OF_CONDUCT

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,3 +230,6 @@ the gem to github packages.
 
 Everyone interacting in the JustApi project's codebases, issue trackers, chat
 rooms and mailing lists is expected to follow the [code of conduct][].
+
+
+[code of conduct]: https://github.com/justifi-tech/justifi-ruby/blob/main/CODE_OF_CONDUCT.md


### PR DESCRIPTION
The `[link text][]` style for links in Markdown are considered "reference links", and assumes that there is a "reference" somewhere else in the document (usually at the bottom):

> ### Links
>
> Markdown supports two style of links: inline and reference.
>
> In both styles, the link text is delimited by `[square brackets]`.
>
> Reference-style links use a second set of square brackets, inside
> which you place a label of your choosing to identify the link:
>
> This is `[an example][id]` reference-style link.
>
> You can optionally use a space to separate the sets of brackets:
>
> This is `[an example] [id]` reference-style link.
>
> Then, anywhere in the document, you define your link label like this, on
> a line by itself:
>
> ```
> [id]: http://example.com/  "Optional Title Here"
> ```
>
> That is:
>
> * Square brackets containing the link identifier (optionally indented
>   from the left margin using up to three spaces);
> * followed by a colon;
> * followed by one or more spaces (or tabs);
> * followed by the URL for the link;
> * optionally followed by a title attribute for the link, enclosed
>   in double or single quotes, or enclosed in parentheses.
>

( from https://daringfireball.net/projects/markdown/syntax#link )

Why I added this previously in 821868c (PR #26), I forgot the reference section, so the link was not displaying properly when rendered.


Type of Change
--------------

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update
* [ ] This change is in scope for PCI
* [ ] This requires approval from UX
* [ ] This requires approval from Marketing


Links
-----

* https://github.com/justifi-tech/justifi-ruby/commit/821868c523f4e5f77ee9821b62ed72361b960c2d
* https://github.com/justifi-tech/justifi-ruby/pull/26

Steps for Testing/QA
--------------------

README fix, so no proper QA is required, but when reviewing, it is probably best to view this in the "rendered" diff to confirm the change is there as expected.