### PR TITLE
[PLAT-324] Support pagination in list balance transactions

### DIFF
--- a/lib/justifi/balance_transaction.rb
+++ b/lib/justifi/balance_transaction.rb
@@ -7,7 +7,7 @@ module Justifi
         Justifi.seller_account_deprecation_warning if seller_account_id
         headers[:sub_account] = sub_account_id || seller_account_id if sub_account_id || seller_account_id
 
-        JustifiOperations.execute_get_request("/v1/balance_transactions", params, headers)
+        JustifiOperations.list("/v1/balance_transactions", params, headers)
       end
 
       def get(id:, headers: {})

--- a/lib/justifi/version.rb
+++ b/lib/justifi/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Justifi
-  VERSION = "0.6.4"
+  VERSION = "0.6.5"
 end

--- a/spec/justifi/balance_transaction_spec.rb
+++ b/spec/justifi/balance_transaction_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Justifi::BalanceTransaction do
       end
 
       it do
-        expect(justifi_object).to be_a(Justifi::JustifiObject)
+        expect(justifi_object).to be_a(Justifi::ListObject)
         expect(justifi_object.raw_response.http_status).to eq(200)
       end
     end


### PR DESCRIPTION
- fix: support pagination in list balance transaction


Type of Change
--------------

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update
* [ ] This change is in scope for PCI
* [ ] This requires approval from UX
* [ ] This requires approval from Marketing


Links
-----

https://justifi-ai.atlassian.net/browse/PLAT-324


Steps for Testing/QA
--------------------

Checkout branch, run the Gem's console pointing to staging:

```sh
API_STAGING_BASE_URL=https://api.xyz bin/console
```

Setup the SDK using a platform's credentials:

```ruby
Justifi.setup(client_id: "", client_secret: "", environment: "staging")
```

- [x] `Justifi::BalanceTransaction.list(sub_account_id: "acc_xyz")` should support pagination

