### PR TITLE
[PLAT-146] Add get balance transactions for payment request

### DIFF
--- a/lib/justifi/payment.rb
+++ b/lib/justifi/payment.rb
@@ -49,9 +49,9 @@ module Justifi
           headers: {})
       end
 
-      def balance_transactions(payment_id:, headers: {})
+      def balance_transactions(payment_id:, params: {}, headers: {})
         Justifi::ListObject.list("/v1/payments/#{payment_id}/payment_balance_transactions",
-          {},
+          params,
           headers)
       end
     end

--- a/lib/justifi/payment.rb
+++ b/lib/justifi/payment.rb
@@ -25,7 +25,7 @@ module Justifi
         Justifi.seller_account_deprecation_warning if seller_account_id
         headers[:sub_account] = sub_account_id || seller_account_id if sub_account_id || seller_account_id
 
-        JustifiOperations.execute_get_request("/v1/payments", params, headers)
+        Justifi::ListObject.list("/v1/payments", params, headers)
       end
 
       def get(payment_id:, headers: {})

--- a/lib/justifi/payment.rb
+++ b/lib/justifi/payment.rb
@@ -48,6 +48,12 @@ module Justifi
           params: params,
           headers: {})
       end
+
+      def balance_transactions(payment_id:, headers: {})
+        Justifi::ListObject.list("/v1/payments/#{payment_id}/payment_balance_transactions",
+          {},
+          headers)
+      end
     end
   end
 end

--- a/lib/justifi/version.rb
+++ b/lib/justifi/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Justifi
-  VERSION = "0.6.6"
+  VERSION = "0.6.7"
 end

--- a/spec/justifi/payment_spec.rb
+++ b/spec/justifi/payment_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe Justifi::Payment do
       end
 
       it do
-        expect(justifi_object).to be_a(Justifi::JustifiObject)
+        expect(justifi_object).to be_a(Justifi::ListObject)
         expect(justifi_object.raw_response.http_status).to eq(200)
       end
     end

--- a/spec/justifi/payment_spec.rb
+++ b/spec/justifi/payment_spec.rb
@@ -200,4 +200,22 @@ RSpec.describe Justifi::Payment do
       end
     end
   end
+
+  describe "#balance_transactions" do
+    let(:list_balance_transactions) { subject.send(:balance_transactions, payment_id: payment_id) }
+
+    context "with valid params" do
+      let(:justifi_object) { list_balance_transactions }
+
+      before do
+        Stubs::Payment.success_create(payment_params)
+        Stubs::Payment.success_balance_transactions(payment_id)
+      end
+
+      it do
+        expect(justifi_object).to be_a(Justifi::ListObject)
+        expect(justifi_object.raw_response.http_status).to eq(200)
+      end
+    end
+  end
 end

--- a/spec/stubs/payments.rb
+++ b/spec/stubs/payments.rb
@@ -254,6 +254,48 @@ module Stubs
           .with(headers: DEFAULT_HEADERS)
           .to_return(status: 200, body: response_body, headers: {})
       end
+
+      def success_balance_transactions(payment_id)
+        response_body = {
+          "id" => nil,
+          "type" => "array",
+          "page_info" => {
+            "has_previous" => false,
+            "has_next" => false,
+            "start_cursor" => "WyIyMDIzLTAyLTIzIDE5OjIwOjQzLjk1NDEzNDAwMCIsImMzMGQ5NGZlLTc5MDktNGQ5OS04Zjg1LTg5ODYzOTlhYzFiNiJd",
+            "end_cursor" => "WyIyMDIzLTAyLTIzIDE5OjIwOjQzLjkyMjUxNDAwMCIsIjVmODUzMGIyLWE0YzQtNDUxOC1iMjcwLWQxYTdkNGEwYmU1NiJd"
+          },
+          "data" => [{
+            "id" => "pbt_5w3i49NrufNWRFp3P2WJoE",
+            "amount" => -201050,
+            "balance" => 6498950,
+            "created_at" => "2023-02-23T19:20:43.954Z",
+            "currency" => "usd",
+            "financial_transaction_id" => "ft_1FDoN0PwcML87cuEQc8sld",
+            "payment_id" => "py_5PuA93RcM5rzrWmcGpuze1",
+            "payment_balance_txn_type" => "payment_fee",
+            "source_id" => "fee_5k291sviJPFan3ALLC1S6l",
+            "source_type" => "ApplicationFee",
+            "updated_at" => "2023-02-23T19:20:43.954Z"
+          }, {
+            "id" => "pbt_2uF8cxPceBXpbvaMU8ytTK",
+            "amount" => 6700000,
+            "balance" => 6700000,
+            "created_at" => "2023-02-23T19:20:43.922Z",
+            "currency" => "usd",
+            "financial_transaction_id" => "ft_1FDoN0PwcML87cuEQc8sld",
+            "payment_id" => "py_5PuA93RcM5rzrWmcGpuze1",
+            "payment_balance_txn_type" => "payment",
+            "source_id" => "py_5PuA93RcM5rzrWmcGpuze1",
+            "source_type" => "Payment",
+            "updated_at" => "2023-02-23T19:20:43.922Z"
+          }]
+        }.to_json
+
+        WebMock.stub_request(:get, "#{Justifi.api_url}/v1/payments/#{payment_id}/payment_balance_transactions")
+          .with(headers: DEFAULT_HEADERS)
+          .to_return(status: 200, body: response_body, headers: {})
+      end
     end
   end
 end


### PR DESCRIPTION
- fix: payment list supports pagination
- feat: impl payment balance transactions
- chore: specs for payment balance transactions


Type of Change
--------------

* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update
* [ ] This change is in scope for PCI
* [ ] This requires approval from UX
* [ ] This requires approval from Marketing


Links
-----

https://justifi-ai.atlassian.net/browse/PLAT-146


Steps for Testing/QA
--------------------

Checkout branch, run the Gem's console pointing to staging:

```sh
API_STAGING_BASE_URL=https://api.xyz bin/console
```

Setup the SDK using a platform's credentials:

```ruby
Justifi.setup(client_id: "", client_secret: "", environment: "staging")
```

- [x] `Justifi::Payment.list` should now support pagination
- [x] `Justifi::Payment.balance_transactions(payment_id: "py_xpto")` should list balance transactions for a payment

