### PR TITLE
Expose API error details in Justifi::Error to improve user-facing messages

### DIFF
--- a/lib/justifi/justifi_error.rb
+++ b/lib/justifi/justifi_error.rb
@@ -2,17 +2,22 @@
 
 module Justifi
   class Error < StandardError
-    attr_reader :response_code
+    attr_reader :response_code, :http_error_detail
 
-    def initialize(response_code, msg)
+    def initialize(response_code, msg, http_error_detail: nil)
       super(msg)
       @response_code = response_code
+      @http_error_detail = http_error_detail
     end
   end
 
   class InvalidHttpResponseError < Error
     def initialize(response:)
-      super(response.http_status, response.error_message)
+      super(
+        response.http_status,
+        response.error_message,
+        http_error_detail: response.error_details,
+      )
     end
   end
 end

--- a/lib/justifi/justifi_response.rb
+++ b/lib/justifi/justifi_response.rb
@@ -68,6 +68,9 @@ module Justifi
     # The error error_message from JustiFi API
     attr_accessor :error_message
 
+    # The error hash from JustiFi API
+    attr_accessor :error_details
+
     # The boolean flag based on Net::HTTPSuccess
     attr_accessor :success
 
@@ -79,6 +82,7 @@ module Justifi
       resp.http_body = http_resp.body
       resp.success = http_resp.is_a? Net::HTTPSuccess
       resp.error_message = resp.data.dig(:error, :message)
+      resp.error_details = resp.data.dig(:error)
       JustifiResponseBase.populate_for_net_http(resp, http_resp)
       resp
     end


### PR DESCRIPTION
### Rationale
The Justifi API provides a detailed error hash in the response body when a payment fails. However, the `Justifi::Error` class currently only extracts and retains the `message` field from this hash, discarding other valuable context that could help with debugging.

This PR introduces a method to expose the full error details while following the existing pattern used for storing the message.

### Changes
- Added a method to `Justifi::Error` to access the complete error details.
- Preserved the existing behavior to avoid breaking changes.

### Notes
- I am unable to run the test suite due to lack of credentials, so this PR serves as a suggested change rather than a fully validated implementation.
- I have not included new tests since I cannot run them, but the approach follows existing patterns in the codebase.

### Links
N/A
