### PR TITLE
add: error_detail hash in Justifi::Error class

### DIFF
--- a/lib/justifi/justifi_error.rb
+++ b/lib/justifi/justifi_error.rb
@@ -2,17 +2,18 @@
 
 module Justifi
   class Error < StandardError
-    attr_reader :response_code
+    attr_reader :response_code, :error_details
 
-    def initialize(response_code, msg)
+    def initialize(response_code, msg, error_details: nil)
       super(msg)
       @response_code = response_code
+      @error_details = error_details
     end
   end
 
   class InvalidHttpResponseError < Error
     def initialize(response:)
-      super(response.http_status, response.error_message)
+      super(response.http_status, response.error_message, error_details: response.error_details)
     end
   end
 end

--- a/lib/justifi/justifi_response.rb
+++ b/lib/justifi/justifi_response.rb
@@ -58,6 +58,8 @@ module Justifi
   # the Justifi API.
   class JustifiResponse
     include JustifiResponseBase
+    extend Gem::Deprecate
+
     # The data contained by the HTTP body of the response deserialized from
     # JSON.
     attr_accessor :data
@@ -71,6 +73,9 @@ module Justifi
     # The boolean flag based on Net::HTTPSuccess
     attr_accessor :success
 
+    # The error hash from JustiFi API
+    attr_accessor :error_details
+
     # Initializes a JustifiResponse object from a Net::HTTP::HTTPResponse
     # object.
     def self.from_net_http(http_resp)
@@ -79,6 +84,7 @@ module Justifi
       resp.http_body = http_resp.body
       resp.success = http_resp.is_a? Net::HTTPSuccess
       resp.error_message = resp.data.dig(:error, :message)
+      resp.error_details = resp.data.dig(:error)
       JustifiResponseBase.populate_for_net_http(resp, http_resp)
       resp
     end

--- a/lib/justifi/version.rb
+++ b/lib/justifi/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Justifi
-  VERSION = "0.9.0"
+  VERSION = "0.10.0"
 end

--- a/spec/stubs/payments.rb
+++ b/spec/stubs/payments.rb
@@ -299,6 +299,31 @@ module Stubs
           .with(headers: DEFAULT_HEADERS)
           .to_return(status: 200, body: response_body, headers: {})
       end
+
+      def fail_create_sub_account_header_required
+        error_response = {
+          "error" => {
+            "param" => "base",
+            "code" => "sub_account_header_required",
+            "message" => "Missing required header: Sub-Account"
+          }
+        }.to_json
+
+        WebMock.stub_request(:post, "#{Justifi.api_url}/v1/payments")
+          .to_return(status: 400, body: error_response, headers: {})
+      end
+
+      def fail_create_not_authorized
+        error_response = {
+          "error" => {
+            "code" => "not_authorized",
+            "message" => "Not Authorized"
+          }
+        }.to_json
+
+        WebMock.stub_request(:post, "#{Justifi.api_url}/v1/payments")
+          .to_return(status: 401, body: error_response, headers: {})
+      end
     end
   end
 end


### PR DESCRIPTION
Details
---

As suggested in https://github.com/justifi-tech/justifi-ruby/pull/54, we're adding the `error_details` hash inside Justifi::Error for better visiblity and control over error responses.

Commits
---
- **add: error_details to Justifi::Error class**
- **add: error_details to payments specs**
- **v0.10.0**

<!--
Describe the rationale and use case for this pull request.  Provide any
background, examples, and images that provide further information to accurately
describe what it is that you are adding to the repo.  Add subsections as
necessary to organize and feel free to link and reference other PRs as
necessary, but also include them in the links section below as a quick
reference.

**Guidelines:**

* Keep Pull Request titles short and to the point, ideally under 72 characters
* Provide as much context/info in the description as necessary to get the
  reviewer up to the same domain knowledge level as yourself
* Keep code changes as short as possible and implementing a single
  feature/fix/refactoring, when possible
-->

Type of Change
--------------

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update
* [ ] This change is in scope for PCI
* [ ] This requires approval from UX
* [ ] This requires approval from Marketing


Links
-----

<!--
**Examples** 

* http://documentation.for/library/that/I/am/adding
* [relevant issue or pull_request](#123)
-->


Steps for Testing/QA
--------------------

<!--
If there are any manual steps that you would like the reviewer(s) to take to
verify your changes, please describe in detail the steps to reproduce the
features added by the pull request, or the bug before and after the change.
-->
